### PR TITLE
Long context token predictability

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,43 @@ behavior is `False`.
 loadAll: False
 ```
 
+#### `stride`
+
+When using models with a fixed context length (like `gpt2`), care needs to be
+taken with calculating the predictability measures of a token in long contexts
+which exceed the maximum length of the model. In these cases, we use a striding
+window strategy. You can use `stride` to control the size of the stride. The
+default behavior is half of the maximum length allowed by the model. 
+
+```yaml
+stride: 100
+```
+
+To make this clear, here is an example. Suppose the maximum context length was
+5, each word was represented as one token, and our stride was 3. The following
+sentence would cause problems: 
+
+`the strange boy is outside and the girl saw him`
+
+As it has 10 words, but the model only allows for 5. Using a stride would yield
+the following fragments, over which predictability measures are calculated: 
+
+`the strange boy is outside`
+
+`is outside and the girl`
+
+`the girl saw him`
+
+The first occurrence of the word is where it's probability is calculated. So for
+example, `outside` is `P(outside | the strange boy is)` and `girl` is `P(girl |
+is outside and the)`. 
+
+Note that for certain models, special tokens are appended to the start and end
+of a text (like [CLS]). At the moment, we handle this just for masked language
+models. Importantly, these additional tokens interact with stride, as we have
+implemented it. They are ignored in calculating the stride jumps and maximum
+context length. So, in effect, the maximum length is less than the total allowed
+(by two for now, though future versions should handle this more rigorously). 
 
 ## Config Details for `analyze`
 The `analyze` mode is designed to take the predictions from the `evaluate` mode and generate summaries that are relevant to each experiment type. More details can be found in the following markdown files in `src/analysis/`: `MinimalPairAnalysis.md`, `TextClassificationAnalysis.md`, and `TokenClassificationAnalysis.md`. 

--- a/README.md
+++ b/README.md
@@ -234,15 +234,15 @@ classification with `numLabels`. Note: you must specify a value if
 numLabels: 5
 ```
 
-#### `maxSequenceLength`
+#### `maxTrainSequenceLength`
 
 In loading a model, you can specify the maximum sequence length (i.e., the
-context size) with `maxSequenceLength`. This changes the sequence length of the
+context size) with `maxTrainSequenceLength`. This changes the sequence length of the
 model when loading not from a pretrained model and controls the sequence length
 in a batch during training. The default is 128. 
 
 ```yaml
-maxSequenceLength: 128
+maxTrainSequenceLength: 128
 ```
 
 #### `seed`
@@ -366,18 +366,6 @@ precision: 16bit
 `full`, which loads the model without changing its precision. Selecting `16bit`
 with `train` will train a lower precision model (note: you need to use a GPU for
 this). 
-
-#### `showSpecialTokens`
-
-You can surface special tokens in the output using show `showSpecialTokens`,
-which takes a boolean: 
-
-```yaml
-showSpecialTokens: True
-```
-
-If set to `True`, the model returns non-pad special tokens used internal to the
-model architecture (e.g., [CLS]).
 
 #### `PLL_type`
 

--- a/src/classifiers/Classifier.py
+++ b/src/classifiers/Classifier.py
@@ -22,7 +22,6 @@ class Classifier:
 
         # Default values
         self.precision = None
-        self.showSpecialTokens = False
         self.device = 'best' 
         self.id2label = None
         self.label2id = None

--- a/src/evaluations/MinimalPair.py
+++ b/src/evaluations/MinimalPair.py
@@ -63,9 +63,7 @@ class MinimalPair(Evaluation):
                 token = LM.tokenizer.convert_ids_to_tokens(measure['token_id'])
 
                 if word is None:
-                    if not LM.showSpecialTokens: 
-                        continue
-                    word = ''
+                    continue
 
                 # Figure out if punctuation 
                 isPunct = False

--- a/src/evaluations/TokenClassification.py
+++ b/src/evaluations/TokenClassification.py
@@ -68,9 +68,7 @@ class TokenClassification(Evaluation):
                 token = Classifier.tokenizer.convert_ids_to_tokens(measure['token_id'])
 
                 if word is None:
-                    if not Classifier.showSpecialTokens: 
-                        continue
-                    word = ''
+                    continue
 
                 if alignment is not None and alignment < len(targets):
                     target = targets[alignment]
@@ -187,7 +185,5 @@ class TokenClassification(Evaluation):
                 print_out = f"{token: <20} | {modelName: <24} | {label: <11}" \
                 f" | {prob: >10}"
                 if unit is None:
-                    if Classifier.showSpecialTokens:
-                        print(print_out)
                     continue
                 print(print_out)

--- a/src/models/LM.py
+++ b/src/models/LM.py
@@ -49,22 +49,6 @@ class LM:
         return self.modelname
 
     @torch.no_grad()
-    def get_output(self, text: Union[str, List[str]]) -> dict:
-        """ Returns model output for text
-
-        Args:
-            text (`Union[str, List[str]]`): A (batch of) strings.
-
-        Returns:
-            `dict`: Dictionary with input_ids, last_non_masked_idx, and logits.
-                    input_ids are the input ids from the tokenizer.
-                    last_non_masked_idx is the index right before padding starts
-                    of shape batch_size. Logits has shape (batch_size, number of
-                    tokens, vocab_size).
-        """
-        raise NotImplementedError
-
-    @torch.no_grad()
     def get_hidden_layers(self, text: Union[str, List[str]]) -> dict:
         """ Returns model hidden layer representations for text
 
@@ -72,13 +56,11 @@ class LM:
             text (`Union[str, List[str]]`): A (batch of) strings.
 
         Returns:
-            `dict`: Dictionary with input_ids, last_non_masked_idx, and
-                    hidden_layers.
+            `dict`: Dictionary with input_ids and hidden_layers.
                     input_ids are the input ids from the tokenizer.
-                    last_non_masked_idx is the index right before padding starts
-                    of shape batch_size. hidden_layers is a tuple of length
-                    number of layers (including embeddings). Each element has
-                    shape (batch_size, number of tokens, hidden_size).
+                    hidden_layers is a tuple of length number of layers
+                    (including embeddings). Each element has shape (batch_size,
+                    number of tokens, hidden_size).
         """
 
         raise NotImplementedError
@@ -113,54 +95,12 @@ class LM:
                     token. Each dictionary has token_id, probability, surprisal.
                     Note: the padded output is included.
         """
-        output = self.get_output(text)
-        input_ids = output['input_ids']
-        last_non_masked_idx = output['last_non_masked_idx']
-        
-        by_token_probabilities, by_token_surprisals = \
-                    self.convert_to_predictability(output['logits'])
-
-        # If predictions are offset (as with causal LMs) then shift targets
-        # using a zero vector for surprisal and a ones vector for probability.
-        # This has the added benefit of making the first prediction value zero
-        # for surprisal and one for probability.
-        if self.offset:
-            by_token_probabilities = torch.cat((torch.ones(
-                                        by_token_probabilities.size(0), 1,
-                                     by_token_probabilities.size(-1)).to(self.device),
-                                         by_token_probabilities), 
-                                         dim = 1)
-            by_token_surprisals = torch.cat((torch.zeros(
-                                                by_token_surprisals.size(0), 1, 
-                                                by_token_surprisals.size(-1)).to(self.device),
-                                         by_token_surprisals), 
-                                         dim = 1)
-            last_non_masked_idx = last_non_masked_idx + 1
-
-        by_token_probabilities = by_token_probabilities.gather(-1,
-                                                      input_ids.unsqueeze(2)).squeeze(-1)
-        by_token_surprisals = by_token_surprisals.gather(-1,
-                                                      input_ids.unsqueeze(2)).squeeze(-1)
-
-        # For each batch, zip together input ids and predictability measures
-        # into dictionaries 
-        data = []
-        for i in range(by_token_surprisals.size(0)):
-            row = []
-            for group in zip(input_ids[i, :], 
-                        by_token_probabilities[i,:], 
-                        by_token_surprisals[i,:],
-                             strict=True):
-                row.append({'token_id': int(group[0]), 
-                            'probability': float(group[1]), 
-                            'surprisal': float(group[2])})
-            data.append(row)
-        return data
+        raise NotImplementedError
 
     @torch.no_grad()
-    def get_by_sentence_perplexity(self, text: Union[str, List[str]]
-                                  ) -> dict:
-        """ Returns perplexity of each batch (e.g., sentence) for inputted text.
+    def get_by_batch_perplexity(self, text: Union[str, List[str]], 
+                                  add_special_tokens=False) -> dict:
+        """ Returns perplexity of each batch for inputted text.
             Note that this requires that you've implemented
             `get_by_token_predictability`.
 
@@ -175,6 +115,12 @@ class LM:
 
         Args: 
             text (`Union[str, List[str]]`): A (batch of) strings.
+            add_special_tokens (`bool`): Whether to add special tokens like CLS
+                and SEP. NOTE: This does not change the internal computation for
+                getting logits. That necessarily adds CLS and SEP. This flag is
+                for the alignment to text, where we do not return information
+                about CLS and SEP because we do not return predictability
+                measures for them.  Default is False. 
 
         Returns:
             `dict`: Dictionary with two keys: text, which contains the text,
@@ -188,7 +134,8 @@ class LM:
             text = [text]
         all_ppls = []
         batched_token_predicts = self.get_by_token_predictability(text)
-        batched_alignments = self.tokenizer.align_words_ids(text)
+        batched_alignments = self.tokenizer.align_words_ids(text,
+                                        add_special_tokens=add_special_tokens)
         for token_predicts, alignments_words in zip(batched_token_predicts,
                                                     batched_alignments,
                                                     strict=True):
@@ -242,7 +189,8 @@ class LM:
 
         all_data = []
         batched_token_predicts = self.get_by_token_predictability(text)
-        batched_alignments = self.tokenizer.align_words_ids(text)
+        batched_alignments = self.tokenizer.align_words_ids(text, 
+                                        add_special_tokens=add_special_tokens)
         for token_predicts, alignments_words in zip(batched_token_predicts,
                                                     batched_alignments,
                                                     strict=True):

--- a/src/models/LM.py
+++ b/src/models/LM.py
@@ -25,10 +25,9 @@ class LM:
         # Default values
         self.getHidden = False
         self.precision = None
-        self.showSpecialTokens = False
         self.device = 'best' 
         self.loadPretrained = True
-        self.maxSequenceLength = 128
+        self.maxTrainSequenceLength = 128
         self.stride = None
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -214,7 +213,7 @@ class LM:
 
     @torch.no_grad()
     def get_aligned_words_predictabilities(self, text: Union[str, List[str]], 
-                                          ) -> List[List[WordPred]]:
+                                          add_special_tokens=False) -> List[List[WordPred]]:
         """ Returns predictability measures of each word for inputted text.
            Note that this requires `get_by_token_predictability`.
 
@@ -229,6 +228,12 @@ class LM:
 
         Args:
             text (`Union[str, List[str]]`): A (batch of) strings.
+            add_special_tokens (`bool`): Whether to add special tokens like CLS
+                and SEP. NOTE: This does not change the internal computation for
+                getting logits. That necessarily adds CLS and SEP. This flag is
+                for the alignment to text, where we do not return information
+                about CLS and SEP because we do not return predictability
+                measures for them.  Default is False. 
 
         Returns:
             `List[List[WordPred]]`: List of lists for each batch comprised of
@@ -260,14 +265,6 @@ class LM:
                     isUnk = True
                 # This is a special token (e.g., [CLS], [PAD])
                 if word is None:
-                    # Surface only when requested (still ignoring pad)
-                    if (self.showSpecialTokens and 
-                       self.tokenizer.pad_token_id != measure['token_id']):
-                        word = self.tokenizer.convert_ids_to_tokens(
-                            measure['token_id'])
-                        sentence_data.append(WordPred(word, surp, prob, isSplit,
-                                                      isUnk, self.modelname,
-                                                      self.tokenizer.tokenizername))
                     prob = 1
                     surp = 0
 

--- a/src/models/LM.py
+++ b/src/models/LM.py
@@ -29,6 +29,7 @@ class LM:
         self.device = 'best' 
         self.loadPretrained = True
         self.maxSequenceLength = 128
+        self.stride = None
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -89,8 +90,7 @@ class LM:
 
         Args:
             logits (`torch.Tensor`): logits with shape (batch_size,
-                                            number of tokens, vocab_size),
-                                        as in output of get_output()
+                                            number of tokens, vocab_size)
 
         Returns:
             `torch.Tensor`: probabilities and surprisals (base 2) each 
@@ -105,7 +105,6 @@ class LM:
     def get_by_token_predictability(self, text: Union[str, List[str]]
                                                      ) -> list: 
         """ Returns predictability measure of each token for inputted text.
-           Note that this requires `get_output`.
 
         Args:
             text (`Union[str, List[str]]`): A (batch of) strings.
@@ -163,7 +162,8 @@ class LM:
     def get_by_sentence_perplexity(self, text: Union[str, List[str]]
                                   ) -> dict:
         """ Returns perplexity of each batch (e.g., sentence) for inputted text.
-            Note that this requires that you've implemented `get_output`.
+            Note that this requires that you've implemented
+            `get_by_token_predictability`.
 
            Perpelixty for autoregressive models is defined as: 
             .. math::
@@ -216,7 +216,7 @@ class LM:
     def get_aligned_words_predictabilities(self, text: Union[str, List[str]], 
                                           ) -> List[List[WordPred]]:
         """ Returns predictability measures of each word for inputted text.
-           Note that this requires `get_output`.
+           Note that this requires `get_by_token_predictability`.
 
         WordPred Object: 
             word: word in text

--- a/src/models/TODO.md
+++ b/src/models/TODO.md
@@ -1,0 +1,7 @@
+- [ ] Masked language modeling with a sliding window needs more work. 
+    - [ ] Care with adding to each batch 
+    - [ ] Refactor the handling of CLS and SEP, perhaps again we need something like 0/1 for both 
+- [ ] Refactor to remove last_non_masked_idx 
+- [ ] Test masked model with sliding window at edge of context length, the CLS/SEP addition has a two token mismatch between what I am viewing as context and what the model sees
+- [ ] Refactor ppl calculator (or ensure it is still working) and rename as
+  per-batch ppl 

--- a/src/models/TODO.md
+++ b/src/models/TODO.md
@@ -1,7 +1,0 @@
-- [ ] Masked language modeling with a sliding window needs more work. 
-    - [ ] Care with adding to each batch 
-    - [ ] Refactor the handling of CLS and SEP, perhaps again we need something like 0/1 for both 
-- [ ] Refactor to remove last_non_masked_idx 
-- [ ] Test masked model with sliding window at edge of context length, the CLS/SEP addition has a two token mismatch between what I am viewing as context and what the model sees
-- [ ] Refactor ppl calculator (or ensure it is still working) and rename as
-  per-batch ppl 

--- a/src/models/hf_causal_model.py
+++ b/src/models/hf_causal_model.py
@@ -60,8 +60,107 @@ class HFCausalModel(LM):
 
         self.model.eval()
 
+        # Set stride to half max length if you haven't specified it
+        if self.stride is None:
+            self.stride = int(self.tokenizer.model_max_length//2)
+
     @torch.no_grad()
-    def get_output(self, texts: Union[str, List[str]]):
+    def get_by_token_predictability(self, texts: Union[str, List[str]]
+                                                     ) -> list: 
+        # batchify 
+        if isinstance(texts, str):
+            texts = [texts]
+
+        MAX_LENGTH = self.tokenizer.model_max_length
+
+        inputs_dict = self.tokenizer(texts, 
+                                     padding=True,
+                                     return_tensors='pt').to(self.device)
+        input_ids = inputs_dict['input_ids']
+        attn_mask = inputs_dict['attention_mask']
+
+        seq_len = input_ids.size(1)
+
+        # Adapted from HuggingFace's perpelxity for fixed length models 
+        # https://huggingface.co/docs/transformers/main/en/perplexity
+        prev_end_loc = 0
+        data = []
+        for begin_loc in range(0, seq_len, self.stride):
+            end_loc = min(begin_loc + MAX_LENGTH, seq_len)
+            trg_len = end_loc - prev_end_loc
+            strided_input_ids = input_ids[:,begin_loc:end_loc].to(self.device)
+            strided_attn_mask = attn_mask[:,begin_loc:end_loc].to(self.device)
+
+            strided_input = {'input_ids': strided_input_ids, 
+                             'attention_mask': strided_attn_mask}
+
+            logits = self.model(**strided_input).logits
+
+            by_token_probabilities, by_token_surprisals = \
+                    self.convert_to_predictability(logits)
+            # Shift targets because predictions are offest using a zero vector
+            # for surprisal and a ones vector for probability. This has the
+            # added benefit of making the first prediction value zero for
+            # surprisal and one for probability
+            by_token_probabilities = torch.cat((torch.ones(
+                                        by_token_probabilities.size(0), 1,
+                                     by_token_probabilities.size(-1)).to(self.device),
+                                         by_token_probabilities), 
+                                         dim = 1)
+            by_token_surprisals = torch.cat((torch.zeros(
+                                                by_token_surprisals.size(0), 1, 
+                                                by_token_surprisals.size(-1)).to(self.device),
+                                         by_token_surprisals), 
+                                         dim = 1)
+
+            # Get by token measures 
+            by_token_probabilities = by_token_probabilities.gather(-1,
+                                               strided_input_ids.unsqueeze(2)).squeeze(-1)
+            by_token_surprisals = by_token_surprisals.gather(-1,
+                                                strided_input_ids.unsqueeze(2)).squeeze(-1)
+
+            # Extract the actual targets (those predictions which are new)
+            by_token_probabilities = by_token_probabilities[:, -trg_len:]
+            by_token_surprisals = by_token_surprisals[:, -trg_len:]
+            strided_input_ids = strided_input_ids[:, -trg_len:]
+
+            # For each batch, zip together input ids and predictability measures
+            # into dictionaries 
+            for i in range(by_token_surprisals.size(0)):
+                row = []
+                for group in zip(strided_input_ids[i, :], 
+                            by_token_probabilities[i,:], 
+                            by_token_surprisals[i,:],
+                                 strict=True):
+                    row.append({'token_id': int(group[0]), 
+                                'probability': float(group[1]), 
+                                'surprisal': float(group[2])})
+                if data == []:
+                    data.append(row)
+                else:
+                    data[i].extend(row)
+
+            prev_end_loc = end_loc
+            # Wrap up if you've reached the end with the current chunk
+            if end_loc == seq_len:
+                break
+
+        return data
+
+    @torch.no_grad()
+    def get_logits(self, texts: Union[str, List[str]]):
+        """ Returns model logits for text
+
+        Args:
+            texts (`Union[str, List[str]]`): A (batch of) strings.
+
+        Returns:
+            `dict`: Dictionary with input_ids, last_non_masked_idx, and logits.
+                    input_ids are the input ids from the tokenizer.
+                    last_non_masked_idx is the index right before padding starts
+                    of shape batch_size. Logits has shape (batch_size, number of
+                    tokens, vocab_size).
+        """
         
         # batchify 
         if isinstance(texts, str):

--- a/src/models/hf_causal_model.py
+++ b/src/models/hf_causal_model.py
@@ -47,8 +47,8 @@ class HFCausalModel(LM):
             auto_config = AutoConfig.from_pretrained(
                             modelname, 
                             vocab_size = len(self.tokenizer), 
-                            n_positions = self.maxSequenceLength,
-                            max_position_embeddings = self.maxSequenceLength,
+                            n_positions = self.maxTrainSequenceLength,
+                            max_position_embeddings = self.maxTrainSequenceLength,
                             bos_token_id = self.tokenizer.bos_token_id, 
                             eos_token_id = self.tokenizer.eos_token_id,
                         )

--- a/src/tokenizers/hf_tokenizer.py
+++ b/src/tokenizers/hf_tokenizer.py
@@ -170,12 +170,13 @@ class HFTokenizer(Tokenizer):
                      padding=padding, truncation=truncation, 
                      max_length = max_length, return_tensors=return_tensors)
 
-    def align_words_ids(self, text):
+    def align_words_ids(self, text, add_special_tokens=False):
         # batchify 
         if isinstance(text, str):
             text = [text]
         text = self.LowerCaseText(text)
-        encoded = self._tokenizer(text, padding=True)
+        encoded = self._tokenizer(text, padding=True, 
+                                  add_special_tokens=False)
         data = []
         for batch in range(len(encoded['input_ids'])):
             mapping = encoded.word_ids(batch)

--- a/src/tokenizers/hf_tokenizer.py
+++ b/src/tokenizers/hf_tokenizer.py
@@ -57,6 +57,14 @@ class HFTokenizer(Tokenizer):
     def mask_token_id(self) -> int:
         return self._tokenizer.mask_token_id
 
+    @property 
+    def sep_token_id(self) -> int:
+        return self._tokenizer.sep_token_id
+
+    @property 
+    def cls_token_id(self) -> int:
+        return self._tokenizer.cls_token_id
+
     def IsSkipTokenID(self, token_id: int) -> bool:
         """ Whether the token id is for a skippable token. We consider cls, sep,
         and beginning of sentence tokens skippable. Note that eos is not included. 

--- a/src/utils/load_kwargs.py
+++ b/src/utils/load_kwargs.py
@@ -3,11 +3,10 @@ def load_kwargs(config: dict) -> dict:
 
     """
     kwargs = {}
-    optional = ['getHidden', 'precision', 'device', 'showSpecialTokens', 
+    optional = ['getHidden', 'precision', 'device', 
                 'PLL_type', 'id2label', 'addPadToken', 'doLower',
                 'addPrefixSpace', 'loadAll', 'checkFileColumns', 
                'batchSize', 'verbose', 
-                'maxSequenceLength',
                'loadPretrained', 'numLabels', 
                 # dataset args
                 'seed',
@@ -29,7 +28,7 @@ def load_kwargs(config: dict) -> dict:
                 'load_best_model_at_end',
                 'wholeWordMasking',
                 'maskProbability',
-                'maxSequenceLength',
+                'maxTrainSequenceLength',
                 # analysis args
                 'predfpath',
                 'datafpath',

--- a/src/utils/load_kwargs.py
+++ b/src/utils/load_kwargs.py
@@ -8,6 +8,7 @@ def load_kwargs(config: dict) -> dict:
                 'addPrefixSpace', 'loadAll', 'checkFileColumns', 
                'batchSize', 'verbose', 
                'loadPretrained', 'numLabels', 
+                'stride', 
                 # dataset args
                 'seed',
                 'samplePercent',

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -16,7 +16,6 @@ config = {'models':
            ["ynie/roberta-large-snli_mnli_fever_anli_R1_R2_R3-nli"]}}
 
 kwargs = {
-        'showSpecialTokens': False,
           'loadAll': True,
           'device': 'mps', 
           'batchSize': 10}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,15 +14,29 @@ config = {'models':
             {'hf_causal_model': ['gpt2']},
          }
 
+'''
 config = {'models': 
             {'hf_masked_model': ['bert-base-cased']},
          }
+'''
 
 model = load_models(config)[0]
 
-text = ['the boy is outside and the girl is with him.', 
-        'the girl']
+from datasets import load_dataset
+
+test = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+text = '\n\n'.join(test['text'])
+
+text = [' '.join(text.split(' ')[:512]), ' '.join(text.split(' ')[512:1044])]
+
+output = model.get_by_batch_perplexity(text)
+for x in range(len(output['text'])):
+    print(output['perplexity'][x], output['text'][x])
+
+'''
 data = model.get_aligned_words_predictabilities(text)
 for batch in data:
     for word in batch:
         print(word.word, word.surp, word.prob)
+    print()
+'''

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,14 +14,15 @@ config = {'models':
             {'hf_causal_model': ['gpt2']},
          }
 
+config = {'models': 
+            {'hf_masked_model': ['bert-base-cased']},
+         }
+
 model = load_models(config)[0]
 
-text = ['the boy is outside.']
-print(model.get_by_sentence_perplexity(text))
-
-input_ids = model.tokenizer(text, return_tensors='pt', padding=True).to(model.device)
-loss = model.model(**input_ids, labels=input_ids['input_ids']).loss
-print(loss)
-loss = loss/torch.log(torch.tensor(2.0))
-print(loss, 2**loss)
-
+text = ['the boy is outside and the girl is with him.', 
+        'the girl']
+data = model.get_by_token_predictability(text)
+for batch in data:
+    for word in batch:
+        print(word)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,7 +22,7 @@ model = load_models(config)[0]
 
 text = ['the boy is outside and the girl is with him.', 
         'the girl']
-data = model.get_by_token_predictability(text)
+data = model.get_aligned_words_predictabilities(text)
 for batch in data:
     for word in batch:
-        print(word)
+        print(word.word, word.surp, word.prob)


### PR DESCRIPTION
Now by token predictability for fixed length models extends to larger contexts. Works for `gpt2` and `bert` family. May need more care in handling this for other models, but let's see. 